### PR TITLE
HCK-5008: add plugin adapter to change value type

### DIFF
--- a/adapter/0.1.70.json
+++ b/adapter/0.1.70.json
@@ -1,0 +1,58 @@
+/**
+ * Copyright © 2016-2024 by IntegrIT S.A. dba Hackolade.  All rights reserved.
+ *
+ * The copyright to the computer software herein is the property of IntegrIT S.A.
+ * The software may be used and/or copied only with the written permission of
+ * IntegrIT S.A. or in accordance with the terms and conditions stipulated in
+ * the agreement/contract under which the software has been supplied.
+ *
+ * {
+ * 		"add": {
+ * 			"entity": [<names of new property>],
+ * 			"container": [<names of new property>],
+ * 			"model": [<names of new property>],
+ * 			"view": [<names of new property>],
+ *			"field": {
+ *				"<type>": [<names of new property>]
+ *			}
+ * 		},
+ * 		"delete": {
+ * 			"entity": [<names of new property>],
+ * 			"container": [<names of new property>],
+ * 			"model": [<names of new property>],
+ * 			"view": [<names of new property>],
+ *			"field": {
+ *				"<type>": [<names of new property>]
+ *			}
+ * 		},
+ * 		"modify": {
+ *	 		"entity": [
+ *	 			{
+ *					"from": { <properties that identify record> },
+ *					"to": { <properties that need to be changed> }
+ *				}
+ *			],
+ *			"container": [],
+ *			"model": [],
+ *			"view": [],
+ *			"field": []
+ * 		},
+ * }
+ */
+{
+    "modify": {
+        "field": [
+            [
+                "convertPropertyValueToType",
+                {
+                    "fieldKeyword": "sample",
+                    "convertToType": "number",
+                    "dependency": {
+                        "key": "type",
+                        "value": "numeric"
+                    }
+                }
+            ]
+        ]
+    }
+}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-5008" title="HCK-5008" target="_blank"><img alt="Bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-5008</a>  OpenAPI example property value isn't converted to the correct format in JSON Schema FE
  </td></table>
  <br />
 
<!--jira-description-action-hidden-marker-end-->

## Content

An adapter is added to adjust fields and alter the value type as needed.

## Affected paths

Only plugins equipped with the "convertPropertyValueToType" field modification adaptor are impacted (OpenAPI).

## Technical details

Implemented `convertPropertyValueToType` and defined corresponding types for its API. Types can be found here: 
[link](https://github.com/hackolade/studio/pull/1018)