### PR TITLE
HCK-8865: implemented schema version change for OpenAPI Schema FE

### DIFF
--- a/forward_engineering/api.js
+++ b/forward_engineering/api.js
@@ -10,6 +10,7 @@ const getExtensions = require('./helpers/extensionsHelper');
 const handleReferencePath = require('./helpers/handleReferencePath');
 const mapJsonSchema = require('../reverse_engineering/helpers/adaptJsonSchema/mapJsonSchema');
 const path = require('path');
+const versions = require('../package.json').contributes.target.versions;
 
 module.exports = {
 	generateModelScript(data, logger, cb) {
@@ -23,7 +24,7 @@ module.exports = {
 				jsonSchemaDialect,
 			} = data.modelData[0];
 			const apiTargetVersion = data?.options?.apiTargetVersion;
-			const specVersion = apiTargetVersion ?? dbVersion;
+			const specVersion = apiTargetVersion && versions.includes(apiTargetVersion) ? apiTargetVersion : dbVersion;
 
 			const containersIdsFromCallbacks = commonHelper.getContainersIdsForCallbacks(data);
 

--- a/forward_engineering/api.js
+++ b/forward_engineering/api.js
@@ -15,13 +15,15 @@ module.exports = {
 	generateModelScript(data, logger, cb) {
 		try {
 			const {
-				dbVersion: specVersion,
+				dbVersion,
 				externalDocs: modelExternalDocs,
 				tags: modelTags,
 				security: modelSecurity,
 				servers: modelServers,
 				jsonSchemaDialect,
 			} = data.modelData[0];
+			const appTargetVersion = data?.options?.appTargetVersion;
+			const specVersion = appTargetVersion ?? dbVersion;
 
 			const containersIdsFromCallbacks = commonHelper.getContainersIdsForCallbacks(data);
 

--- a/forward_engineering/api.js
+++ b/forward_engineering/api.js
@@ -22,8 +22,8 @@ module.exports = {
 				servers: modelServers,
 				jsonSchemaDialect,
 			} = data.modelData[0];
-			const appTargetVersion = data?.options?.appTargetVersion;
-			const specVersion = appTargetVersion ?? dbVersion;
+			const apiTargetVersion = data?.options?.apiTargetVersion;
+			const specVersion = apiTargetVersion ?? dbVersion;
 
 			const containersIdsFromCallbacks = commonHelper.getContainersIdsForCallbacks(data);
 


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-8865" title="HCK-8865" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-8865</a>  OpenAPI model version selection without template
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Added support for explicit choice of OpenAPI schema version instead of template