### PR TITLE
HCK-11878: FE additional properties only when its false

### DIFF
--- a/forward_engineering/helpers/typeHelper.js
+++ b/forward_engineering/helpers/typeHelper.js
@@ -248,7 +248,11 @@ function getAdditionalProperties(data) {
 	}
 
 	if (data.additionalPropControl === 'Boolean') {
-		return Boolean(data.additionalProperties) && undefined;
+		/**
+		 * additionalProperties property should be omitted when the value is equal to "true" because it is enabled by default.
+		 * In case the property is missing or false it is explicitly included with "false" value
+		 */
+		return data.additionalProperties ? undefined : false;
 	}
 
 	return getAdditionalPropsObject(data);

--- a/forward_engineering/helpers/typeHelper.js
+++ b/forward_engineering/helpers/typeHelper.js
@@ -247,9 +247,8 @@ function getAdditionalProperties(data) {
 		return;
 	}
 
-	const additionalProperties = Boolean(data.additionalProperties);
-	if (data.additionalPropControl === 'Boolean' && !additionalProperties) {
-		return additionalProperties;
+	if (data.additionalPropControl === 'Boolean') {
+		return data.additionalProperties && undefined;
 	}
 
 	return getAdditionalPropsObject(data);

--- a/forward_engineering/helpers/typeHelper.js
+++ b/forward_engineering/helpers/typeHelper.js
@@ -247,8 +247,9 @@ function getAdditionalProperties(data) {
 		return;
 	}
 
-	if (data.additionalPropControl === 'Boolean') {
-		return data.additionalProperties || undefined;
+	const additionalProperties = Boolean(data.additionalProperties);
+	if (data.additionalPropControl === 'Boolean' && !additionalProperties) {
+		return additionalProperties;
 	}
 
 	return getAdditionalPropsObject(data);

--- a/forward_engineering/helpers/typeHelper.js
+++ b/forward_engineering/helpers/typeHelper.js
@@ -248,7 +248,7 @@ function getAdditionalProperties(data) {
 	}
 
 	if (data.additionalPropControl === 'Boolean') {
-		return data.additionalProperties && undefined;
+		return Boolean(data.additionalProperties) && undefined;
 	}
 
 	return getAdditionalPropsObject(data);


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-11878" title="HCK-11878" target="_blank"><img alt="Bug" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10303?size=medium" />HCK-11878</a>  [Travelers][OpenAPI] FE to OpenAPI file: FE additionalProperties only when it's false
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

FE additionalProperties only when its false