### PR TITLE
HCK-12530: do not include identical modelDefinitions data to all collections

### DIFF
--- a/reverse_engineering/api.js
+++ b/reverse_engineering/api.js
@@ -171,7 +171,7 @@ const handleOpenAPIData = (openAPISchema, fieldOrder) =>
 				const currentEntities = modelContent.entities[container.name];
 				return [
 					...accumulator,
-					...currentEntities.map(entity => {
+					...currentEntities.map((entity, index) => {
 						const packageData = {
 							objectNames: {
 								collectionName: entity.collectionName,
@@ -179,8 +179,8 @@ const handleOpenAPIData = (openAPISchema, fieldOrder) =>
 							doc: {
 								dbName: container.name,
 								collectionName: entity.collectionName,
-								modelDefinitions: definitions,
 								bucketInfo: container,
+								...(index === 0 && { modelDefinitions: definitions }),
 							},
 							jsonSchema: JSON.stringify(entity),
 						};


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12530" title="HCK-12530" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-12530</a>  Remove redundant modelDefinitions data duplication from parsed model
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Removed identical modelDefinitions data from all collections and preserved only in the first one