### PR TITLE
HCK-12560: enabled <extensions> on references

### DIFF
--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -231,6 +231,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
 				"structure": [
@@ -607,6 +608,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
 				"structure": [
@@ -935,6 +937,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
 				"structure": [
@@ -1263,6 +1266,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
 				"structure": [
@@ -1470,6 +1474,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
 				"structure": [
@@ -1631,6 +1636,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
 				"structure": [
@@ -1934,6 +1940,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
 				"structure": [
@@ -2375,6 +2382,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
 				"structure": [
@@ -2443,6 +2451,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
 				"structure": [
@@ -2522,6 +2531,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
 				"structure": [
@@ -2666,6 +2676,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
 				"structure": [
@@ -2737,6 +2748,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
 				"structure": [
@@ -2795,6 +2807,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
 				"structure": [
@@ -2876,6 +2889,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
 				"structure": [
@@ -3337,6 +3351,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
 				"structure": [
@@ -3405,6 +3420,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
 				"structure": [
@@ -3568,6 +3584,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
 				"structure": [
@@ -3679,6 +3696,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
 				"structure": [
@@ -3761,6 +3779,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
 				"structure": [
@@ -3843,6 +3862,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
 				"structure": [
@@ -3925,6 +3945,7 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
 				"structure": [

--- a/properties_pane/field_level/fieldLevelConfig.json
+++ b/properties_pane/field_level/fieldLevelConfig.json
@@ -231,6 +231,44 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
 				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
@@ -251,7 +289,20 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			},
 			{
 				"propertyKeyword": "subtype",
@@ -608,6 +659,44 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
 				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
@@ -628,7 +717,20 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			}
 		],
 		"number": [
@@ -937,6 +1039,44 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
 				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
@@ -957,7 +1097,20 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			}
 		],
 		"integer": [
@@ -1266,6 +1419,44 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
 				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
@@ -1286,7 +1477,20 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			}
 		],
 		"boolean": [
@@ -1474,6 +1678,44 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
 				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
@@ -1494,7 +1736,20 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			}
 		],
 		"null": [
@@ -1636,6 +1891,44 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
 				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
@@ -1656,7 +1949,20 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			}
 		],
 		"array": [
@@ -1940,6 +2246,53 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "and",
+					"values": [
+						{
+							"key": "subtype",
+							"value": "schema"
+						},
+						{
+							"type": "not",
+							"values": [
+								{
+									"key": "refType",
+									"value": "polyglot"
+								},
+								{
+									"key": "refType",
+									"value": "external"
+								}
+							]
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
 				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
@@ -1962,8 +2315,26 @@ making sure that you maintain a proper JSON format.
 					}
 				],
 				"dependency": {
-					"key": "subtype",
-					"value": "schema"
+					"type": "and",
+					"values": [
+						{
+							"key": "subtype",
+							"value": "schema"
+						},
+						{
+							"type": "or",
+							"values": [
+								{
+									"key": "refType",
+									"value": "polyglot"
+								},
+								{
+									"key": "refType",
+									"value": "external"
+								}
+							]
+						}
+					]
 				}
 			}
 		],
@@ -2382,6 +2753,53 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "and",
+					"values": [
+						{
+							"key": "subtype",
+							"value": "schema"
+						},
+						{
+							"type": "not",
+							"values": [
+								{
+									"key": "refType",
+									"value": "polyglot"
+								},
+								{
+									"key": "refType",
+									"value": "external"
+								}
+							]
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
 				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
@@ -2404,8 +2822,26 @@ making sure that you maintain a proper JSON format.
 					}
 				],
 				"dependency": {
-					"key": "subtype",
-					"value": "schema"
+					"type": "and",
+					"values": [
+						{
+							"key": "subtype",
+							"value": "schema"
+						},
+						{
+							"type": "or",
+							"values": [
+								{
+									"key": "refType",
+									"value": "polyglot"
+								},
+								{
+									"key": "refType",
+									"value": "external"
+								}
+							]
+						}
+					]
 				}
 			},
 			"comments",
@@ -2451,6 +2887,44 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
 				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
@@ -2471,7 +2945,20 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			},
 			{
 				"propertyKeyword": "subtype",
@@ -2531,6 +3018,44 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
 				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
@@ -2551,7 +3076,20 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			},
 			{
 				"propertyKeyword": "subtype",
@@ -2676,6 +3214,44 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
 				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
@@ -2696,7 +3272,20 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			},
 			{
 				"propertyKeyword": "subtype",
@@ -2748,6 +3337,44 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
 				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
@@ -2768,7 +3395,20 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			},
 			{
 				"propertyKeyword": "subtype",
@@ -2807,6 +3447,44 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
 				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
@@ -2827,7 +3505,20 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			},
 			{
 				"propertyKeyword": "subtype",
@@ -2889,6 +3580,44 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
 				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
@@ -2909,7 +3638,20 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			},
 			{
 				"propertyKeyword": "subtype",
@@ -3351,6 +4093,44 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
 				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
@@ -3371,7 +4151,20 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			},
 			{
 				"propertyKeyword": "subtype",
@@ -3420,6 +4213,44 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
 				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
@@ -3440,7 +4271,20 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			}
 		],
 		"link": [
@@ -3584,6 +4428,44 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
 				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
@@ -3604,7 +4486,20 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			}
 		],
 		"expression": [
@@ -3696,6 +4591,44 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
 				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
@@ -3716,7 +4649,20 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			},
 			{
 				"propertyKeyword": "subtype",
@@ -3779,6 +4725,44 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
 				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
@@ -3799,7 +4783,20 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			},
 			{
 				"propertyKeyword": "subtype",
@@ -3862,6 +4859,44 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
 				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
@@ -3882,7 +4917,20 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			},
 			{
 				"propertyKeyword": "subtype",
@@ -3945,6 +4993,44 @@ making sure that you maintain a proper JSON format.
 				"propertyName": "extensions",
 				"propertyType": "group",
 				"propertyKeyword": "scopesExtensions",
+				"shouldValidate": true,
+				"propertyTooltip": "",
+				"structure": [
+					{
+						"propertyName": "pattern",
+						"propertyKeyword": "extensionPattern",
+						"shouldValidate": true,
+						"propertyType": "text",
+						"regex": "^x-"
+					},
+					{
+						"propertyName": "value",
+						"propertyKeyword": "extensionValue",
+						"propertyValidate": false,
+						"propertyTooltip": "Popup for multi-line text entry",
+						"propertyType": "details",
+						"template": "textarea",
+						"markdown": false
+					}
+				],
+				"dependency": {
+					"type": "not",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
+			},
+			{
+				"propertyName": "extensions",
+				"propertyType": "group",
+				"propertyKeyword": "scopesExtensions",
 				"enableForReference": true,
 				"shouldValidate": true,
 				"propertyTooltip": "",
@@ -3965,7 +5051,20 @@ making sure that you maintain a proper JSON format.
 						"template": "textarea",
 						"markdown": false
 					}
-				]
+				],
+				"dependency": {
+					"type": "or",
+					"values": [
+						{
+							"key": "refType",
+							"value": "polyglot"
+						},
+						{
+							"key": "refType",
+							"value": "external"
+						}
+					]
+				}
 			},
 			{
 				"propertyKeyword": "subtype",

--- a/reverse_engineering/helpers/dataHelper.js
+++ b/reverse_engineering/helpers/dataHelper.js
@@ -26,6 +26,10 @@ const getExtensions = schema => {
 
 const getExtensionsObject = (data, keyword = 'scopesExtensions') => {
 	const extensions = getExtensions(data);
+	if (extensions.length === 0) {
+		return {};
+	}
+
 	return { [keyword]: extensions };
 };
 
@@ -73,13 +77,14 @@ const getServersData = servers => {
 		}
 
 		const variables = server.variables ? getServersVariables(server.variables) : [];
+		const extensions = getExtensions(server);
 		return [
 			...accum,
 			{
 				serverURL: server.url,
 				serverDescription: server.description,
 				serverVariables: variables,
-				scopesExtensions: getExtensions(server),
+				...(extensions.length > 0 && { scopesExtensions: extensions }),
 			},
 		];
 	}, []);
@@ -88,12 +93,13 @@ const getServersData = servers => {
 const getServersVariables = variables => {
 	return Object.keys(variables).map(variable => {
 		const variableData = variables[variable];
+		const extensions = getExtensions(variables);
 		return {
 			serverVariableName: variable,
 			serverVariableEnum: (variableData.enum || []).map(enumVal => ({ serverVariableEnumValue: enumVal })),
 			serverVariableDefault: variableData.default,
 			serverVariableDescription: variableData.description,
-			scopesExtensions: getExtensions(variables),
+			...(extensions.length > 0 && { scopesExtensions: extensions }),
 		};
 	}, []);
 };
@@ -624,7 +630,7 @@ const handleSchemaExtensions = schema => {
 	const mappedExtensionsObject = getExtensionsObject(schema);
 	if (
 		!Array.isArray(mappedExtensionsObject.scopesExtensions) ||
-		mappedExtensionsObject.scopesExtensions.length === 0
+		mappedExtensionsObject.scopesExtensions?.length === 0
 	) {
 		return schema;
 	}


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12560" title="HCK-12560" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-12560</a>  Enable "Extensions" property in the refrences
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

We want to allow the user change "extensions" property on the references, it is mainly valuable in external and cross-target references.