### PR TITLE
HCK-12591: performance improvements for RE of large schema

### DIFF
--- a/forward_engineering/config.json
+++ b/forward_engineering/config.json
@@ -43,5 +43,7 @@
 			"value": false
 		}
 	],
-	"isApiSchema": true
+	"isApiSchema": true,
+	"disableJSONDataGeneration": true,
+	"disableAttributesSorting": true
 }

--- a/package.json
+++ b/package.json
@@ -117,7 +117,8 @@
                 "propertyNames": [
                     "schemas"
                 ]
-            }
+            },
+            "collapseEntityAttributesInRE": true
         }
     },
     "description": "Hackolade plugin for OpenAPI",

--- a/reverse_engineering/api.js
+++ b/reverse_engineering/api.js
@@ -167,11 +167,16 @@ const handleOpenAPIData = (openAPISchema, fieldOrder) =>
 		try {
 			const convertedData = convertOpenAPISchemaToHackolade(openAPISchema, fieldOrder);
 			const { modelData, modelContent, definitions } = convertedData;
+			let modelDefinitionsWereSet = false;
 			const hackoladeData = modelContent.containers.reduce((accumulator, container) => {
 				const currentEntities = modelContent.entities[container.name];
 				return [
 					...accumulator,
 					...currentEntities.map((entity, index) => {
+						const shouldSetModelDefinitions = !modelDefinitionsWereSet;
+						if (shouldSetModelDefinitions) {
+							modelDefinitionsWereSet = true;
+						}
 						const packageData = {
 							objectNames: {
 								collectionName: entity.collectionName,
@@ -180,7 +185,7 @@ const handleOpenAPIData = (openAPISchema, fieldOrder) =>
 								dbName: container.name,
 								collectionName: entity.collectionName,
 								bucketInfo: container,
-								...(index === 0 && { modelDefinitions: definitions }),
+								...(shouldSetModelDefinitions && { modelDefinitions: definitions }),
 							},
 							jsonSchema: JSON.stringify(entity),
 						};


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12591" title="HCK-12591" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-12591</a>  Improve performance for big OpenAPI model
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

- Fixed model definitions being included only for the first entity.
- Enabled collapsing of entity fields in RE.
- Disabled unnecessary PK field sorting and JSON data generation for FE.