### PR TITLE
HCK-12629: collapse ERD fields only for big models

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,12 @@
                     "schemas"
                 ]
             },
-            "collapseEntityAttributesInRE": true
+            "collapseEntityAttributesInRE": {
+                "erd": true,
+                "erdEntityNumberThreshold": 250,
+                "entityDTD": false,
+                "modelDefinitions": true
+            }
         }
     },
     "description": "Hackolade plugin for OpenAPI",


### PR DESCRIPTION
<!--do not remove this marker, its needed to replace info when ticket title is updated -->
<!--jira-description-action-hidden-marker-start-->

<table>
<td>
  <a href="https://hackolade.atlassian.net/browse/HCK-12629" title="HCK-12629" target="_blank"><img alt="Sub-task" src="https://hackolade.atlassian.net/rest/api/2/universal_avatar/view/type/issuetype/avatar/10316?size=medium" />HCK-12629</a>  Introduce entities number threshold for collapsing RE-d entity fields
  </td></table>
  <br />
 

<!--jira-description-action-hidden-marker-end-->
## Content

Collapse ERD fields after RE only if more than 250 entities were RE-d.