### PR TITLE
chore: address Trivy production dependency vulnerabilities

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
     "name": "OpenAPI",
-    "version": "0.2.18",
+    "version": "0.2.19",
     "lockfileVersion": 3,
     "requires": true,
     "packages": {
         "": {
             "name": "OpenAPI",
-            "version": "0.2.18",
+            "version": "0.2.19",
             "hasInstallScript": true,
             "dependencies": {
                 "@apidevtools/swagger-parser": "10.1.1",
@@ -1736,9 +1736,9 @@
             }
         },
         "node_modules/fast-uri": {
-            "version": "3.1.4",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
-            "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
+            "version": "3.1.5",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
+            "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
             "funding": [
                 {
                     "type": "github",

--- a/package.json
+++ b/package.json
@@ -160,7 +160,7 @@
         "node-uuid": "1.4.7"
     },
     "overrides": {
-        "fast-uri": "3.1.4",
+        "fast-uri": "3.1.5",
         "minimatch": "10.2.4",
         "brace-expansion": "5.0.8"
     }


### PR DESCRIPTION
## Summary
- Address Trivy dependency vulnerabilities for `OpenAPI`: fast-uri override 3.1.4 → 3.1.5 (CVE-2026-18446).
- This plugin was listed in the Plugins released Trivy production report (build 287245).
- Reference: https://teamcity.hackolade.com/buildConfiguration/Plugins_Build/287245?buildTab=report_project9_Released_vulnerabilities

## Test plan
- [x] CI passes
- [x] Plugins released Trivy re-scan no longer reports the fixed package for this plugin
